### PR TITLE
lock docker-dd-agent image to version 5.14.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/docker-dd-agent:latest
+FROM datadog/docker-dd-agent:11.0.5140
 
 RUN apt-get update -qq && apt-get -y install wget && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
locking the `docker-dd-agent` image to version 5.14.0 in the Dockerfile since we've run into issues where an inadvertent version upgrade has caused problems in our applications