### PR TITLE
Revert "Moving to Alpine Linux image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM datadog/docker-dd-agent:latest-alpine
+FROM datadog/docker-dd-agent:12.3.5172
 
-RUN apk --no-cache update && apk upgrade && apk add bash curl wget && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update -qq && apt-get -y install wget && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN cp /entrypoint.sh /dd-entrypoint.sh
 


### PR DESCRIPTION
@pimpolderman I'm going to revert this PR to move to the alpine docker image because it's breaking something with our APM monitoring on WWW and Account Management right now (getting a lot of error messages in loggly about it - but not heroes yet because it's not using the updated dd-agent yet with this change.)

![](http://drops.articulate.com/i8xDks/aeSQRJFYI4+)

It looks like datadog explicitly states that [APM is not available on their alpine images](https://docs.datadoghq.com/tracing/setup/docker/) unfortunately right now.  We'll have to revisit whether we find DD APM useful enough to keep it around or find a new image to run it on with that isn't alpine based.