### PR TITLE
add an apm directory for the :apm tag to build

### DIFF
--- a/apm/Dockerfile
+++ b/apm/Dockerfile
@@ -1,0 +1,17 @@
+# This is a separate Dockerfile for any service that uses Datadog APM
+# because Datadog APM is not available on alpine based images
+# https://docs.datadoghq.com/tracing/setup/docker/
+
+FROM datadog/docker-dd-agent:12.3.5172
+
+RUN apt-get update -qq && apt-get -y install wget && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN cp /entrypoint.sh /dd-entrypoint.sh
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+COPY ../conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml
+
+ENTRYPOINT ["/entrypoint.sh", "/dd-entrypoint.sh"]
+CMD ["supervisord", "-n", "-c", "/etc/dd-agent/supervisor.conf"]


### PR DESCRIPTION
adding an `apm/` directory with it's own Dockerfile to this repo that will build out docker images with the `:apm` tag so services that need Datadog APM can use that image for now and others can use the alpine based image with less vulns on it (since Datadog APM isn't available on the alpine image for now.)

I'm going to go back and change the root `Dockerfile` to be compatible with the alpine image after the new `:apm` image is available and the heroes, account management and www services are changed from `:latest` to use it.  That way nothing will break during the transition on those services DD APM monitoring.