### PR TITLE
Use latest, not a locked version

### DIFF
--- a/apm/Dockerfile
+++ b/apm/Dockerfile
@@ -2,7 +2,7 @@
 # because Datadog APM is not available on alpine based images
 # https://docs.datadoghq.com/tracing/setup/docker/
 
-FROM datadog/docker-dd-agent:12.3.5172
+FROM datadog/docker-dd-agent:latest
 
 RUN apt-get update -qq && apt-get -y install wget && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
We use `latest-alpine` on the main version, this should just be able to be `latest` (which is non-alpine)