### PR TITLE
ci(build): run on merge to master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   schedule:
     - cron: "0 2 * * *"
 


### PR DESCRIPTION
This repo still uses master as the default. While we are building to DockerHub, that can't change